### PR TITLE
fix: open Modal when trigger Button uses a functionCall action

### DIFF
--- a/Sources/A2UISwiftUI/Styling/A2UIStyle.swift
+++ b/Sources/A2UISwiftUI/Styling/A2UIStyle.swift
@@ -693,6 +693,10 @@ private struct A2UIImageResolverKey: EnvironmentKey {
     static let defaultValue: A2UIImageResolver? = nil
 }
 
+private struct A2UITriggerActivationKey: EnvironmentKey {
+    static let defaultValue: (@Sendable () -> Void)? = nil
+}
+
 extension EnvironmentValues {
     public var a2uiStyle: A2UIStyle {
         get { self[A2UIStyleKey.self] }
@@ -709,6 +713,15 @@ extension EnvironmentValues {
     public var a2uiImageResolver: A2UIImageResolver? {
         get { self[A2UIImageResolverKey.self] }
         set { self[A2UIImageResolverKey.self] = newValue }
+    }
+
+    /// Internal: containers (e.g. Modal) inject this to learn that a descendant
+    /// Button trigger was activated, regardless of `Action` kind. Unlike
+    /// `a2uiActionHandler` — which deliberately reports only resolved server
+    /// events — this also fires for pure client-side `functionCall` actions.
+    var a2uiTriggerActivationHandler: (@Sendable () -> Void)? {
+        get { self[A2UITriggerActivationKey.self] }
+        set { self[A2UITriggerActivationKey.self] = newValue }
     }
 
 }

--- a/Sources/A2UISwiftUI/Views/Components/A2UIButton.swift
+++ b/Sources/A2UISwiftUI/Views/Components/A2UIButton.swift
@@ -46,6 +46,51 @@ struct A2UIButton: View {
     }
 }
 
+// MARK: - Action handling
+
+/// Executes a Button's `Action`. Shared by `ButtonActionView` and unit tests.
+///
+/// `onTriggerActivated` fires first, for BOTH action kinds: containers such as
+/// Modal rely on it to detect that their trigger was activated. `functionCall`
+/// actions never reach `actionHandler` (there is no server event name), so
+/// activation must not be inferred from it.
+@MainActor
+func a2uiHandleButtonAction(
+    _ action: Action,
+    componentId: String,
+    dataContext dc: DataContext,
+    surface: SurfaceModel,
+    actionHandler: ((ResolvedAction) -> Void)?,
+    onTriggerActivated: (() -> Void)?
+) {
+    // Action-kind-independent activation notice — regardless of whether the
+    // action later succeeds (mirrors how event actions dispatch unconditionally).
+    onTriggerActivated?()
+    switch action {
+    case .event(let name, let ctx):
+        var resolvedContext: [String: AnyCodable] = [:]
+        if let ctx = ctx {
+            for (key, dv) in ctx {
+                resolvedContext[key] = dc.resolveDynamicValue(dv) ?? .null
+            }
+        }
+        // Dispatch to SurfaceModel → MessageProcessor → server.
+        // Context is resolved before dispatch, mirroring WebCore where the renderer
+        // calls DataContext.resolveAction() before surface.dispatchAction().
+        surface.dispatchAction(name: name, sourceComponentId: componentId, context: resolvedContext)
+        // Notify the host app's local SwiftUI action handler.
+        if let handler = actionHandler {
+            handler(ResolvedAction(name: name, sourceComponentId: componentId, context: resolvedContext))
+        }
+    case .functionCall(let fc):
+        // Pure client-side execution: resolve via DataContext (handles arg resolution,
+        // function invocation, and error dispatching). No server dispatch or actionHandler
+        // notification — there is no server event name. Trigger activation was already
+        // reported above via onTriggerActivated.
+        _ = dc.resolveDynamicValue(.functionCall(fc))
+    }
+}
+
 // MARK: - ButtonActionView
 
 /// Wrapper that reads `a2uiActionHandler` from environment and invokes it on tap.
@@ -59,35 +104,20 @@ struct ButtonActionView<Label: View>: View {
     @ViewBuilder let label: () -> Label
 
     @Environment(\.a2uiActionHandler) private var actionHandler
+    @Environment(\.a2uiTriggerActivationHandler) private var triggerActivationHandler
     @Environment(\.a2uiStyle) private var style
 
     private var variant: ButtonVariant_Enum { props.variant ?? .default }
 
     private func handleAction() {
-        let action = props.action
-        let dc = DataContext(surface: surface, path: dataContextPath)
-        switch action {
-        case .event(let name, let ctx):
-            var resolvedContext: [String: AnyCodable] = [:]
-            if let ctx = ctx {
-                for (key, dv) in ctx {
-                    resolvedContext[key] = dc.resolveDynamicValue(dv) ?? .null
-                }
-            }
-            // Dispatch to SurfaceModel → MessageProcessor → server.
-            // Context is resolved before dispatch, mirroring WebCore where the renderer
-            // calls DataContext.resolveAction() before surface.dispatchAction().
-            surface.dispatchAction(name: name, sourceComponentId: componentId, context: resolvedContext)
-            // Notify the host app's local SwiftUI action handler.
-            if let handler = actionHandler {
-                handler(ResolvedAction(name: name, sourceComponentId: componentId, context: resolvedContext))
-            }
-        case .functionCall(let fc):
-            // Pure client-side execution: resolve via DataContext (handles arg resolution,
-            // function invocation, and error dispatching). No server dispatch or actionHandler
-            // notification needed — there is no server event name.
-            _ = dc.resolveDynamicValue(.functionCall(fc))
-        }
+        a2uiHandleButtonAction(
+            props.action,
+            componentId: componentId,
+            dataContext: DataContext(surface: surface, path: dataContextPath),
+            surface: surface,
+            actionHandler: actionHandler,
+            onTriggerActivated: triggerActivationHandler
+        )
     }
 
     var body: some View {

--- a/Sources/A2UISwiftUI/Views/Components/A2UIModal.swift
+++ b/Sources/A2UISwiftUI/Views/Components/A2UIModal.swift
@@ -23,7 +23,9 @@ import A2UISwiftCore
 /// - `content` (required): component ID displayed inside the sheet.
 ///
 /// Rendering strategy:
-/// - Trigger renders as-is; interaction is handled by the Button inside it (action handler intercept).
+/// - Trigger renders as-is; the Button inside it reports activation via the
+///   `a2uiTriggerActivationHandler` environment (any action kind), with an
+///   `a2uiActionHandler` intercept kept for custom-component triggers.
 /// - Content is presented via `.sheet` with `NavigationStack` + `ScrollView`.
 /// - Close button uses `.cancellationAction` placement (top-leading, standard iOS dismiss position).
 ///
@@ -68,6 +70,16 @@ struct ModalNodeView: View {
             node: triggerNode,
             surface: surface
         )
+        // Action-kind-independent path: fires for BOTH event and functionCall
+        // actions on the built-in Button (functionCall never reaches a2uiActionHandler).
+        .environment(\.a2uiTriggerActivationHandler) {
+            MainActor.assumeIsolated {
+                uiState.isPresented = true
+            }
+        }
+        // Kept alongside the trigger-activation handler: custom catalog components
+        // used as triggers report activation only through a2uiActionHandler, and
+        // event actions must still be forwarded to the host's handler.
         .environment(\.a2uiActionHandler) { action in
             MainActor.assumeIsolated {
                 uiState.isPresented = true

--- a/Tests/A2UISwiftUITests/ModalTriggerActivationTests.swift
+++ b/Tests/A2UISwiftUITests/ModalTriggerActivationTests.swift
@@ -1,0 +1,103 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import A2UISwiftCore
+import Foundation
+import Testing
+
+@testable import A2UISwiftUI
+
+// Regression coverage for https://github.com/BBC6BAE9/a2ui-swift/issues/76:
+// a Modal whose trigger Button carries a functionCall action never opened,
+// because Modal inferred trigger activation from `a2uiActionHandler`, which
+// fires only for event actions.
+//
+// These tests exercise the same dispatch function the SwiftUI Button invokes
+// on tap (`a2uiHandleButtonAction`): `onTriggerActivated` must fire for BOTH
+// Action kinds, while `actionHandler` keeps its host contract (resolved
+// server events only).
+
+@MainActor
+@Suite("Button trigger activation (Modal open path)")
+struct ModalTriggerActivationTests {
+
+    private func makeSurface() -> SurfaceModel {
+        SurfaceModel(id: "test", catalog: basicCatalog)
+    }
+
+    @Test("functionCall action fires onTriggerActivated (issue #76)")
+    func functionCallFiresTriggerActivation() {
+        let surface = makeSurface()
+        let dc = DataContext(surface: surface, path: "/")
+        var activated = false
+        var hostActions: [ResolvedAction] = []
+
+        a2uiHandleButtonAction(
+            .functionCall(FunctionCall(
+                call: "required",
+                args: ["input": .string("x")],
+                returnType: nil
+            )),
+            componentId: "openBtn",
+            dataContext: dc,
+            surface: surface,
+            actionHandler: { hostActions.append($0) },
+            onTriggerActivated: { activated = true }
+        )
+
+        #expect(activated, "functionCall trigger must report activation so Modal can present")
+        // Host contract unchanged: no synthesized ResolvedAction for functionCalls.
+        #expect(hostActions.isEmpty)
+    }
+
+    @Test("unknown function still fires onTriggerActivated")
+    func unknownFunctionStillFiresTriggerActivation() {
+        let surface = makeSurface()
+        let dc = DataContext(surface: surface, path: "/")
+        var activated = false
+
+        a2uiHandleButtonAction(
+            .functionCall(FunctionCall(call: "noSuchFunction", args: [:], returnType: nil)),
+            componentId: "openBtn",
+            dataContext: dc,
+            surface: surface,
+            actionHandler: nil,
+            onTriggerActivated: { activated = true }
+        )
+
+        #expect(activated, "activation must not be gated on the function resolving")
+    }
+
+    @Test("event action fires onTriggerActivated and still notifies actionHandler")
+    func eventFiresBothTriggerActivationAndActionHandler() {
+        let surface = makeSurface()
+        let dc = DataContext(surface: surface, path: "/")
+        var activated = false
+        var hostActions: [ResolvedAction] = []
+
+        a2uiHandleButtonAction(
+            .event(name: "open", context: nil),
+            componentId: "openBtn",
+            dataContext: dc,
+            surface: surface,
+            actionHandler: { hostActions.append($0) },
+            onTriggerActivated: { activated = true }
+        )
+
+        #expect(activated)
+        #expect(hostActions.count == 1)
+        #expect(hostActions.first?.name == "open")
+        #expect(hostActions.first?.sourceComponentId == "openBtn")
+    }
+}


### PR DESCRIPTION
Fixes #76

## Problem

In the SwiftUI renderer, a `Modal` whose trigger `Button` carries a `functionCall` action can never open. `ModalNodeView` detected trigger activation by overriding the `a2uiActionHandler` environment, but `A2UIButton.handleAction()` only notifies that handler for `event` actions — `functionCall` actions execute client-side and never reach it. Since `Action` permits `functionCall` on any Button, this is a schema-valid payload whose tap runs the function but silently never presents the modal.

## Fix

- **New internal `a2uiTriggerActivationHandler` environment value** (`A2UIStyle.swift`): an action-kind-independent "trigger was activated" notification. It is deliberately separate from `a2uiActionHandler`, which keeps its host contract of reporting only resolved server events — no synthesized `ResolvedAction`s are pushed to host apps for functionCalls.
- **`A2UIButton`**: `handleAction()` body extracted verbatim into an internal, testable `a2uiHandleButtonAction(...)` that invokes the trigger-activation closure first, before the switch — so it fires for both `event` and `functionCall` actions, regardless of whether the function resolves.
- **`A2UIModal`**: `ModalNodeView` injects the trigger-activation closure to set `isPresented`. The existing `a2uiActionHandler` intercept is kept alongside it: custom catalog components used as triggers report activation only through `a2uiActionHandler`, and event actions must still be forwarded to the host's handler.

## Tests

`Tests/A2UISwiftUITests/ModalTriggerActivationTests.swift` exercises the same dispatch function the view invokes on tap:

- `functionCall` action fires `onTriggerActivated` and does **not** notify `actionHandler` (host contract guard) — this is the failing case before the fix
- unknown function name still fires `onTriggerActivated` (activation isn't gated on the function resolving)
- `event` action fires `onTriggerActivated` **and** still delivers the `ResolvedAction` (name + sourceComponentId) to `actionHandler`

Full suite passes: `swift test` — 331 swift-testing tests + all XCTest targets, no new warnings.

## Out of scope

- The deprecated `v_08` modal (`A2UIModal_V08.swift`) has the same intercept pattern; left untouched per the frozen-module policy.
- The in-development UIKit/AppKit renderer (`Sources/A2UIPlatform`) has an analogous gap (`surface.onAction` fires only for event actions); noted in #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
